### PR TITLE
Add message edit and delete event support

### DIFF
--- a/jupyter_ai_router/router.py
+++ b/jupyter_ai_router/router.py
@@ -12,7 +12,7 @@ from functools import partial
 import re
 from dataclasses import replace
 from jupyterlab_chat.models import Message
-from pycrdt import ArrayEvent
+from pycrdt import ArrayEvent, MapEvent, Subscription
 from traitlets.config import LoggingConfigurable
 
 if TYPE_CHECKING:
@@ -42,10 +42,12 @@ class MessageRouter(LoggingConfigurable):
     """
     Router that manages ychat message routing.
 
-    The Router provides three callback points:
+    The Router provides five callback points:
     1. When new chats are initialized
     2. When slash commands are received
     3. When regular (non-slash) messages are received
+    4. When existing messages are edited
+    5. When messages are deleted
     """
 
     def __init__(self, *args, **kwargs):
@@ -55,13 +57,16 @@ class MessageRouter(LoggingConfigurable):
         self.chat_init_observers: List[Callable[[str, "YChat"], Any]] = []
         self.slash_cmd_observers: Dict[str, Dict[str, List[Callable[[str, str, Message], Any]]]] = {}
         self.chat_msg_observers: Dict[str, List[Callable[[str, Message], Any]]] = {}
+        self.chat_msg_edit_observers: Dict[str, List[Callable[[str, Message], Any]]] = {}
+        self.chat_msg_delete_observers: Dict[str, List[Callable[[str, Message], Any]]] = {}
         self.chat_reset_observers: List[Callable[[str, "YChat"], Any]] = []
 
         # Active chat rooms
         self.active_chats: Dict[str, "YChat"] = {}
 
-        # Root observers for keeping track of incoming messages
-        self.message_observers: Dict[str, Callable] = {}
+        # Root observers for keeping track of incoming messages.
+        # Stores Subscription objects returned by observe_deep().
+        self.message_observers: Dict[str, Subscription] = {}
 
     def observe_chat_init(self, callback: Callable[[str, "YChat"], Any]) -> None:
         """
@@ -123,6 +128,38 @@ class MessageRouter(LoggingConfigurable):
         self.chat_msg_observers[room_id].append(callback)
         self.log.info("Registered message callback")
 
+    def observe_msg_edit(
+        self, room_id: str, callback: Callable[[str, Message], Any]
+    ) -> None:
+        """
+        Register a callback for when an existing message is edited.
+
+        Args:
+            room_id: The chat room ID
+            callback: Function called with (room_id: str, message: Message) for edited messages
+        """
+        if room_id not in self.chat_msg_edit_observers:
+            self.chat_msg_edit_observers[room_id] = []
+
+        self.chat_msg_edit_observers[room_id].append(callback)
+        self.log.info("Registered message edit callback")
+
+    def observe_msg_delete(
+        self, room_id: str, callback: Callable[[str, Message], Any]
+    ) -> None:
+        """
+        Register a callback for when a message is deleted (soft-delete).
+
+        Args:
+            room_id: The chat room ID
+            callback: Function called with (room_id: str, message: Message) for deleted messages
+        """
+        if room_id not in self.chat_msg_delete_observers:
+            self.chat_msg_delete_observers[room_id] = []
+
+        self.chat_msg_delete_observers[room_id].append(callback)
+        self.log.info("Registered message delete callback")
+
     def connect_chat(self, room_id: str, ychat: "YChat") -> None:
         """
         Connect a new chat session to the router.
@@ -137,10 +174,12 @@ class MessageRouter(LoggingConfigurable):
 
         self.active_chats[room_id] = ychat
 
-        # Set up message observer
-        callback = partial(self._on_message_change, room_id, ychat)
-        ychat.ymessages.observe(callback)
-        self.message_observers[room_id] = callback
+        # Set up deep message observer to catch inserts, edits, and deletes.
+        # observe_deep fires for both structural array changes (inserts/removals)
+        # and nested YMap mutations (field edits on existing messages).
+        callback = partial(self._on_message_change_deep, room_id, ychat)
+        subscription = ychat.ymessages.observe_deep(callback)
+        self.message_observers[room_id] = subscription
 
         self.log.info(f"Connected chat {room_id} to router")
 
@@ -169,17 +208,53 @@ class MessageRouter(LoggingConfigurable):
         del self.active_chats[room_id]
         self.log.info(f"Disconnected chat {room_id} from router")
 
-    def _on_message_change(
-        self, room_id: str, ychat: "YChat", events: ArrayEvent
+    def _on_message_change_deep(
+        self, room_id: str, ychat: "YChat", events: list
     ) -> None:
-        """Handle incoming messages from YChat."""
-        for change in events.delta:  # type: ignore[attr-defined]
-            if "insert" not in change.keys():
-                continue
+        """Handle all message changes from YChat (new, edit, delete).
 
-            new_messages = [Message(**m.to_py()) for m in change["insert"]]
-            for message in new_messages:
-                self._route_message(room_id, message)
+        This is registered via ``observe_deep`` on ``ychat.ymessages``, so it
+        receives a list of events covering both structural array changes
+        (``ArrayEvent`` for inserts/removals) and nested YMap mutations
+        (``MapEvent`` for field edits on existing messages).
+        """
+        for event in events:
+            if isinstance(event, ArrayEvent):
+                # Structural change — new messages inserted into the array
+                for change in event.delta:  # type: ignore[attr-defined]
+                    if "insert" not in change.keys():
+                        continue
+                    new_messages = [Message(**m.to_py()) for m in change["insert"]]
+                    for message in new_messages:
+                        self._route_message(room_id, message)
+
+            elif isinstance(event, MapEvent):
+                # Nested change — a message's fields were edited in place
+                self._handle_message_field_change(room_id, ychat, event)
+
+    def _handle_message_field_change(
+        self, room_id: str, ychat: "YChat", event: MapEvent
+    ) -> None:
+        """Handle in-place edits to an existing message's fields.
+
+        ``event.path`` is ``[index]`` where *index* is the position of the
+        mutated message in ``ychat.ymessages``.  ``event.keys`` is a dict
+        mapping changed field names to ``{action, oldValue, newValue}``.
+        """
+        try:
+            index = event.path[0]
+            raw = ychat.ymessages[index].to_py()
+            message = Message(**raw)
+        except (IndexError, KeyError, TypeError, Exception) as e:
+            self.log.warning(f"Could not resolve edited message in {room_id}: {e}")
+            return
+
+        changed_keys = set(event.keys.keys())
+
+        if "deleted" in changed_keys and message.deleted:
+            self._notify_msg_delete_observers(room_id, message)
+        elif "body" in changed_keys and not message.deleted:
+            self._notify_msg_edit_observers(room_id, message)
 
     def _route_message(self, room_id: str, message: Message) -> None:
         """
@@ -243,6 +318,24 @@ class MessageRouter(LoggingConfigurable):
             except Exception as e:
                 self.log.error(f"Message observer error for {room_id}: {e}")
 
+    def _notify_msg_edit_observers(self, room_id: str, message: Message) -> None:
+        """Notify all message edit observers."""
+        callbacks = self.chat_msg_edit_observers.get(room_id, [])
+        for callback in callbacks:
+            try:
+                callback(room_id, message)
+            except Exception as e:
+                self.log.error(f"Message edit observer error for {room_id}: {e}")
+
+    def _notify_msg_delete_observers(self, room_id: str, message: Message) -> None:
+        """Notify all message delete observers."""
+        callbacks = self.chat_msg_delete_observers.get(room_id, [])
+        for callback in callbacks:
+            try:
+                callback(room_id, message)
+            except Exception as e:
+                self.log.error(f"Message delete observer error for {room_id}: {e}")
+
     def _on_chat_reset(self, room_id, ychat: "YChat") -> None:
         """
         Method to call when the YChat undergoes a document reset, e.g. when the
@@ -271,5 +364,7 @@ class MessageRouter(LoggingConfigurable):
         self.chat_init_observers.clear()
         self.slash_cmd_observers.clear()
         self.chat_msg_observers.clear()
+        self.chat_msg_edit_observers.clear()
+        self.chat_msg_delete_observers.clear()
 
         self.log.info("MessageRouter cleanup complete")

--- a/jupyter_ai_router/tests/test_message_router.py
+++ b/jupyter_ai_router/tests/test_message_router.py
@@ -6,6 +6,7 @@ import pytest
 from unittest.mock import Mock, MagicMock
 from jupyterlab_chat.models import Message
 from jupyterlab_chat.ychat import YChat
+from pycrdt import ArrayEvent, MapEvent
 from jupyter_ai_router.router import MessageRouter, matches_pattern
 from jupyter_ai_router.utils import get_first_word, is_persona
 
@@ -51,6 +52,8 @@ class TestMessageRouter:
         assert len(router.chat_init_observers) == 0
         assert len(router.slash_cmd_observers) == 0
         assert len(router.chat_msg_observers) == 0
+        assert len(router.chat_msg_edit_observers) == 0
+        assert len(router.chat_msg_delete_observers) == 0
         assert len(router.active_chats) == 0
 
     def test_observe_chat_init(self):
@@ -130,6 +133,8 @@ class TestMessageRouter:
         assert len(self.router.chat_init_observers) == 0
         assert len(self.router.slash_cmd_observers) == 0
         assert len(self.router.chat_msg_observers) == 0
+        assert len(self.router.chat_msg_edit_observers) == 0
+        assert len(self.router.chat_msg_delete_observers) == 0
 
 
     def test_matches_pattern_exact(self):
@@ -409,4 +414,239 @@ class TestMessageRouter:
         )
         self.router._route_message(room_id, normal_regular_msg)
         msg_callback.assert_called_once()
+
+
+class TestMessageEditDeleteObservers:
+    """Test edit and delete observer functionality."""
+
+    def setup_method(self):
+        self.router = MessageRouter()
+        self.mock_ychat = Mock(spec=YChat)
+        self.mock_ychat.ymessages = Mock()
+
+    def test_observe_msg_edit(self):
+        """Test registering a message edit callback."""
+        room_id = "test-room"
+        callback = Mock()
+        self.router.observe_msg_edit(room_id, callback)
+        assert callback in self.router.chat_msg_edit_observers[room_id]
+
+    def test_observe_msg_delete(self):
+        """Test registering a message delete callback."""
+        room_id = "test-room"
+        callback = Mock()
+        self.router.observe_msg_delete(room_id, callback)
+        assert callback in self.router.chat_msg_delete_observers[room_id]
+
+    def test_notify_msg_edit_observers(self):
+        """Test that edit observers are notified correctly."""
+        room_id = "test-room"
+        callback = Mock()
+        self.router.observe_msg_edit(room_id, callback)
+
+        msg = Message(id="1", body="edited text", sender="user", time=123)
+        self.router._notify_msg_edit_observers(room_id, msg)
+        callback.assert_called_once_with(room_id, msg)
+
+    def test_notify_msg_delete_observers(self):
+        """Test that delete observers are notified correctly."""
+        room_id = "test-room"
+        callback = Mock()
+        self.router.observe_msg_delete(room_id, callback)
+
+        msg = Message(id="1", body="deleted text", sender="user", time=123, deleted=True)
+        self.router._notify_msg_delete_observers(room_id, msg)
+        callback.assert_called_once_with(room_id, msg)
+
+    def test_edit_observer_error_handling(self):
+        """Test that errors in edit observers don't propagate."""
+        room_id = "test-room"
+        error_callback = Mock(side_effect=Exception("Test error"))
+        self.router.observe_msg_edit(room_id, error_callback)
+
+        msg = Message(id="1", body="edited", sender="user", time=123)
+        # Should not raise
+        self.router._notify_msg_edit_observers(room_id, msg)
+        error_callback.assert_called_once()
+
+    def test_delete_observer_error_handling(self):
+        """Test that errors in delete observers don't propagate."""
+        room_id = "test-room"
+        error_callback = Mock(side_effect=Exception("Test error"))
+        self.router.observe_msg_delete(room_id, error_callback)
+
+        msg = Message(id="1", body="deleted", sender="user", time=123, deleted=True)
+        # Should not raise
+        self.router._notify_msg_delete_observers(room_id, msg)
+        error_callback.assert_called_once()
+
+    def test_handle_message_field_change_body_edit(self):
+        """Test that body edits trigger edit observers."""
+        room_id = "test-room"
+        edit_callback = Mock()
+        delete_callback = Mock()
+        self.router.observe_msg_edit(room_id, edit_callback)
+        self.router.observe_msg_delete(room_id, delete_callback)
+
+        # Create a mock ychat with a message at index 0
+        mock_msg_map = Mock()
+        mock_msg_map.to_py.return_value = {
+            "id": "msg-1", "body": "edited text", "sender": "user",
+            "time": 123, "deleted": False,
+        }
+        self.mock_ychat.ymessages.__getitem__ = Mock(return_value=mock_msg_map)
+
+        # Simulate a MapEvent for body edit
+        event = Mock(spec=MapEvent)
+        event.path = [0]
+        event.keys = {"body": {"action": "update", "oldValue": "original", "newValue": "edited text"}}
+
+        self.router._handle_message_field_change(room_id, self.mock_ychat, event)
+
+        # Edit observer should fire, delete should not
+        edit_callback.assert_called_once()
+        delete_callback.assert_not_called()
+        called_msg = edit_callback.call_args[0][1]
+        assert called_msg.body == "edited text"
+
+    def test_handle_message_field_change_soft_delete(self):
+        """Test that setting deleted=True triggers delete observers."""
+        room_id = "test-room"
+        edit_callback = Mock()
+        delete_callback = Mock()
+        self.router.observe_msg_edit(room_id, edit_callback)
+        self.router.observe_msg_delete(room_id, delete_callback)
+
+        mock_msg_map = Mock()
+        mock_msg_map.to_py.return_value = {
+            "id": "msg-1", "body": "some text", "sender": "user",
+            "time": 123, "deleted": True,
+        }
+        self.mock_ychat.ymessages.__getitem__ = Mock(return_value=mock_msg_map)
+
+        event = Mock(spec=MapEvent)
+        event.path = [0]
+        event.keys = {"deleted": {"action": "update", "oldValue": False, "newValue": True}}
+
+        self.router._handle_message_field_change(room_id, self.mock_ychat, event)
+
+        # Delete observer should fire, edit should not
+        delete_callback.assert_called_once()
+        edit_callback.assert_not_called()
+        called_msg = delete_callback.call_args[0][1]
+        assert called_msg.deleted is True
+
+    def test_handle_message_field_change_unrelated_field(self):
+        """Test that changes to unrelated fields (like time) don't trigger observers."""
+        room_id = "test-room"
+        edit_callback = Mock()
+        delete_callback = Mock()
+        self.router.observe_msg_edit(room_id, edit_callback)
+        self.router.observe_msg_delete(room_id, delete_callback)
+
+        mock_msg_map = Mock()
+        mock_msg_map.to_py.return_value = {
+            "id": "msg-1", "body": "text", "sender": "user",
+            "time": 999, "deleted": False,
+        }
+        self.mock_ychat.ymessages.__getitem__ = Mock(return_value=mock_msg_map)
+
+        # Only time changed — neither edit nor delete
+        event = Mock(spec=MapEvent)
+        event.path = [0]
+        event.keys = {"time": {"action": "update", "oldValue": 123, "newValue": 999}}
+
+        self.router._handle_message_field_change(room_id, self.mock_ychat, event)
+
+        edit_callback.assert_not_called()
+        delete_callback.assert_not_called()
+
+    def test_handle_message_field_change_index_error(self):
+        """Test graceful handling when message index is out of bounds."""
+        room_id = "test-room"
+        edit_callback = Mock()
+        self.router.observe_msg_edit(room_id, edit_callback)
+
+        self.mock_ychat.ymessages.__getitem__ = Mock(side_effect=IndexError("out of range"))
+
+        event = Mock(spec=MapEvent)
+        event.path = [999]
+        event.keys = {"body": {"action": "update"}}
+
+        # Should not raise
+        self.router._handle_message_field_change(room_id, self.mock_ychat, event)
+        edit_callback.assert_not_called()
+
+    def test_on_message_change_deep_array_event(self):
+        """Test that ArrayEvent inserts are still routed correctly via deep observer."""
+        room_id = "test-room"
+        msg_callback = Mock()
+        self.router.observe_chat_msg(room_id, msg_callback)
+
+        # Simulate an ArrayEvent with insert
+        mock_msg = Mock()
+        mock_msg.to_py.return_value = {
+            "id": "new-1", "body": "hello", "sender": "user",
+            "time": 123, "deleted": False,
+        }
+        event = Mock(spec=ArrayEvent)
+        event.delta = [{"insert": [mock_msg]}]
+
+        self.router._on_message_change_deep(room_id, self.mock_ychat, [event])
+
+        msg_callback.assert_called_once()
+        called_msg = msg_callback.call_args[0][1]
+        assert called_msg.body == "hello"
+
+    def test_on_message_change_deep_map_event(self):
+        """Test that MapEvent field changes are dispatched via deep observer."""
+        room_id = "test-room"
+        edit_callback = Mock()
+        self.router.observe_msg_edit(room_id, edit_callback)
+
+        mock_msg_map = Mock()
+        mock_msg_map.to_py.return_value = {
+            "id": "msg-1", "body": "new body", "sender": "user",
+            "time": 123, "deleted": False,
+        }
+        self.mock_ychat.ymessages.__getitem__ = Mock(return_value=mock_msg_map)
+
+        event = Mock(spec=MapEvent)
+        event.path = [0]
+        event.keys = {"body": {"action": "update", "oldValue": "old", "newValue": "new body"}}
+
+        self.router._on_message_change_deep(room_id, self.mock_ychat, [event])
+
+        edit_callback.assert_called_once()
+
+    def test_connect_chat_uses_observe_deep(self):
+        """Test that connect_chat registers with observe_deep, not observe."""
+        room_id = "test-room"
+        self.router.connect_chat(room_id, self.mock_ychat)
+
+        # Should call observe_deep, not observe
+        self.mock_ychat.ymessages.observe_deep.assert_called_once()
+        self.mock_ychat.ymessages.observe.assert_not_called()
+
+    def test_body_edit_on_deleted_message_ignored(self):
+        """Test that body edits on already-deleted messages don't fire edit observers."""
+        room_id = "test-room"
+        edit_callback = Mock()
+        self.router.observe_msg_edit(room_id, edit_callback)
+
+        mock_msg_map = Mock()
+        mock_msg_map.to_py.return_value = {
+            "id": "msg-1", "body": "edited", "sender": "user",
+            "time": 123, "deleted": True,  # Already deleted
+        }
+        self.mock_ychat.ymessages.__getitem__ = Mock(return_value=mock_msg_map)
+
+        event = Mock(spec=MapEvent)
+        event.path = [0]
+        event.keys = {"body": {"action": "update", "oldValue": "old", "newValue": "edited"}}
+
+        self.router._handle_message_field_change(room_id, self.mock_ychat, event)
+
+        # Should NOT fire — message is deleted
+        edit_callback.assert_not_called()
 


### PR DESCRIPTION
## Summary

- Switches `ymessages.observe()` to `observe_deep()` so that in-place YMap mutations (message body edits, soft-deletes) are detected alongside structural array changes (new message inserts)
- Adds `observe_msg_edit(room_id, callback)` and `observe_msg_delete(room_id, callback)` registration methods
- Fixes `disconnect_chat` to use `Subscription` objects returned by `observe_deep`, rather than storing raw callbacks

## Motivation

When a user edits an existing chat message, the body change happens as an in-place mutation of the nested `pycrdt.Map` inside the `ymessages` array. The current `observe()` (shallow) only fires `ArrayEvent` for structural changes (inserts, removals) — it never sees these nested edits. Similarly, soft-deleting a message sets `deleted=True` on the YMap without any array-level event.

By switching to `observe_deep()`, the router receives both `ArrayEvent` (inserts) and `MapEvent` (field edits) in a single callback, enabling downstream consumers (like persona managers) to react to edits and deletes.

## Changes

| File | What changed |
|-|-|
| `router.py` | `observe_deep` instead of `observe`, new `_on_message_change_deep` handler, `_handle_message_field_change` for `MapEvent` dispatch, `observe_msg_edit`/`observe_msg_delete` methods, edit/delete notification methods |
| `tests/test_message_router.py` | 14 new tests covering edit/delete observers, deep event dispatch, error handling, edge cases |

## Test plan

- [x] All 39 tests pass (25 existing + 14 new)
- [x] Verified `pycrdt.Array.observe_deep` behavior with real YDoc: insert → `ArrayEvent`, body edit → `MapEvent(path=[0], keys={body: ...})`, delete flag → `MapEvent(path=[0], keys={deleted: ...})`
- [x] Existing insert routing is preserved (backward compatible)
- [x] `unobserve(subscription)` correctly stops deep observation
- [ ] Manual test with jupyterlab-chat: edit a sent message → persona re-responds