### PR TITLE
Add `observe_chat_stop()`

### DIFF
--- a/jupyter_ai_router/extension.py
+++ b/jupyter_ai_router/extension.py
@@ -136,6 +136,13 @@ class RouterExtension(ExtensionApp):
                 self.router._on_chat_reset(room_id, new_ychat)
 
             ychat = await yroom.get_jupyter_ydoc(on_reset=_on_ychat_reset)
+
+            def _on_yroom_stop():
+                self.router.disconnect_chat(room_id)
+                self.router._notify_chat_stop_observers(room_id)
+
+            yroom.add_stop_callback(_on_yroom_stop)
+
             return ychat
         except Exception as e:
             self.log.error(f"Error getting chat document for {room_id}: {e}")

--- a/jupyter_ai_router/router.py
+++ b/jupyter_ai_router/router.py
@@ -180,6 +180,8 @@ class MessageRouter(LoggingConfigurable):
             del self.message_observers[room_id]
 
         del self.active_chats[room_id]
+        self.slash_cmd_observers.pop(room_id, None)
+        self.chat_msg_observers.pop(room_id, None)
         self.log.info(f"Disconnected chat {room_id} from router")
 
     def _on_message_change(

--- a/jupyter_ai_router/router.py
+++ b/jupyter_ai_router/router.py
@@ -53,6 +53,7 @@ class MessageRouter(LoggingConfigurable):
 
         # Callback lists
         self.chat_init_observers: List[Callable[[str, "YChat"], Any]] = []
+        self.chat_stop_observers: List[Callable[[str], Any]] = []
         self.slash_cmd_observers: Dict[str, Dict[str, List[Callable[[str, str, Message], Any]]]] = {}
         self.chat_msg_observers: Dict[str, List[Callable[[str, Message], Any]]] = {}
         self.chat_reset_observers: List[Callable[[str, "YChat"], Any]] = []
@@ -72,6 +73,18 @@ class MessageRouter(LoggingConfigurable):
         """
         self.chat_init_observers.append(callback)
         self.log.info("Registered new chat initialization callback")
+
+    def observe_chat_stop(self, callback: Callable[[str], Any]) -> None:
+        """
+        Register a callback for when a chat room's YRoom is permanently stopped
+        (freed from memory). Only fires when `jupyter_server_documents` is
+        installed.
+
+        Args:
+            callback: Function called with (room_id: str) when the room is stopped.
+        """
+        self.chat_stop_observers.append(callback)
+        self.log.info("Registered chat stop callback")
 
     def observe_chat_reset(self, callback: Callable[[str, "YChat"], Any]) -> None:
         """
@@ -234,6 +247,14 @@ class MessageRouter(LoggingConfigurable):
             except Exception as e:
                 self.log.error(f"New chat observer error for {room_id}: {e}")
 
+    def _notify_chat_stop_observers(self, room_id: str) -> None:
+        """Notify all chat stop observers."""
+        for callback in self.chat_stop_observers:
+            try:
+                callback(room_id)
+            except Exception as e:
+                self.log.error(f"Chat stop observer error for {room_id}: {e}")
+
     def _notify_msg_observers(self, room_id: str, message: Message) -> None:
         """Notify all message observers."""
         callbacks = self.chat_msg_observers.get(room_id, [])
@@ -269,6 +290,7 @@ class MessageRouter(LoggingConfigurable):
 
         # Clear callbacks
         self.chat_init_observers.clear()
+        self.chat_stop_observers.clear()
         self.slash_cmd_observers.clear()
         self.chat_msg_observers.clear()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["hatchling>=1.5.0", "jupyterlab>=4.0.0,<5", "hatch-nodejs-version>=0.3.2"]
+requires = [
+    "hatchling>=1.5.0",
+    "jupyterlab>=4.0.0,<5",
+    "hatch-nodejs-version>=0.3.2",
+]
 build-backend = "hatchling.build"
 
 [project]
@@ -25,7 +29,7 @@ classifiers = [
 dependencies = [
     "jupyter_server>=2.4.0,<3",
     "jupyterlab-chat>=0.19.0",
-    "jupyter-collaboration>=4.0.0"
+    "jupyter_server_documents>=0.2.0a0",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
@@ -35,7 +39,7 @@ test = [
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
-    "pytest-jupyter[server]>=0.6.0"
+    "pytest-jupyter[server]>=0.6.0",
 ]
 
 [tool.hatch.version]
@@ -82,7 +86,7 @@ version_cmd = "hatch version"
 before-build-npm = [
     "python -m pip install 'jupyterlab>=4.0.0,<5'",
     "jlpm",
-    "jlpm build:prod"
+    "jlpm build:prod",
 ]
 before-build-python = ["jlpm clean:all"]
 


### PR DESCRIPTION
## Description

- Allows consumers to observe when a chat room was stopped to free memory. 

- Fixes a bug where chat message & slash command observers for a room were not removed after the room was disconnected. Without this fix, every AI persona would receive an extra copy of the message after the chat room is re-opened after being freed.

This requires memory management in JSD. (https://github.com/jupyter-ai-contrib/jupyter-server-documents/pull/193)

## Pending items

- [x] Bump to `jupyter_server_documents>=0.2.0` once released