### PR TITLE
Remove `jupyter_server_documents` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
 dependencies = [
     "jupyter_server>=2.4.0,<3",
     "jupyterlab-chat>=0.19.0",
-    "jupyter_server_documents>=0.2.0a0",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
This dependency is behind a `try` / `except` block here:

https://github.com/jupyter-ai-contrib/jupyter-ai-router/blob/79ff0a4176713d61eedc6befbe16de81a1ca457f/jupyter_ai_router/extension.py#L19-L26

And already part of the `jupyter-ai` metapackage:

https://github.com/jupyterlab/jupyter-ai/blob/69aefb33cf5ad2c0f7c28ed54068d7b2a4b62ba6/pyproject.toml#L32

Fixes https://github.com/jupyter-ai-contrib/jupyter-ai-router/issues/11